### PR TITLE
feat: add eBay draft publishing

### DIFF
--- a/src/app/api/ebay/drafts/route.ts
+++ b/src/app/api/ebay/drafts/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import type { Product } from '@/lib/types';
+import { createEbayDraft } from '@/lib/ebay';
+
+export async function POST(req: Request) {
+  const product = (await req.json()) as Product;
+  try {
+    const result = await createEbayDraft(product);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('eBay draft creation failed', error);
+    return NextResponse.json({ error: 'Failed to create eBay draft' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,6 +234,33 @@ function DashboardClient() {
     }
   };
 
+  const handleSendToEbayDraft = async (product: Product) => {
+    setGeneratingProductId(product.id);
+    try {
+      const res = await fetch('/api/ebay/drafts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(product),
+      });
+      if (!res.ok) {
+        throw new Error('Failed to create eBay draft');
+      }
+      toast({
+        title: 'Sent to eBay',
+        description: `"${product.name}" has been sent to eBay drafts.`,
+      });
+    } catch (error) {
+      console.error('Failed to send to eBay', error);
+      toast({
+        variant: 'destructive',
+        title: 'eBay Draft Failed',
+        description: 'Could not send product to eBay drafts.',
+      });
+    } finally {
+      setGeneratingProductId(null);
+    }
+  };
+
   const handleExportToCSV = () => {
     const headers = [
       'id', 'name', 'code', 'quantity', 'price', 'description', 
@@ -435,6 +462,7 @@ function DashboardClient() {
       onGenerate: handleGenerateDescription,
       onUpdate: handleUpdateProduct,
       onCopyDescription: handleCopyDescription,
+      onSendToEbay: handleSendToEbayDraft,
       generatingProductId,
   }), [generatingProductId, products]);
 

--- a/src/components/product-columns.tsx
+++ b/src/components/product-columns.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from '@tanstack/react-table';
 import Image from 'next/image';
-import { MoreHorizontal, ArrowUpDown, Sparkles, Loader2, Edit, Trash2, Search, Copy } from 'lucide-react';
+import { MoreHorizontal, ArrowUpDown, Sparkles, Loader2, Edit, Trash2, Search, Copy, Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -29,6 +29,7 @@ type GetColumnsProps = {
   onGenerate: (product: Product) => void;
   onUpdate: (id: string, data: Partial<Product>) => void;
   onCopyDescription: (product: Product, source: 'otto' | 'ebay') => void;
+  onSendToEbay: (product: Product) => void;
   generatingProductId: string | null;
 };
 
@@ -39,7 +40,7 @@ const formatCurrency = (amount: number) => {
     }).format(amount);
 }
 
-export const getColumns = ({ onEdit, onDelete, onGenerate, onCopyDescription, generatingProductId }: GetColumnsProps): ColumnDef<Product>[] => [
+export const getColumns = ({ onEdit, onDelete, onGenerate, onCopyDescription, onSendToEbay, generatingProductId }: GetColumnsProps): ColumnDef<Product>[] => [
   {
     id: 'select',
     header: ({ table }) => (
@@ -151,6 +152,10 @@ export const getColumns = ({ onEdit, onDelete, onGenerate, onCopyDescription, ge
                     <DropdownMenuItem onClick={() => onDelete(product.id)} className="text-destructive">
                         <Trash2 className="mr-2 h-4 w-4" />
                         <span>Delete</span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => onSendToEbay(product)}>
+                        <Send className="mr-2 h-4 w-4" />
+                        <span>Send to eBay Drafts</span>
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuGroup>

--- a/src/lib/ebay.ts
+++ b/src/lib/ebay.ts
@@ -1,0 +1,44 @@
+import type { Product } from './types';
+
+const EBAY_API_BASE = process.env.EBAY_API_BASE || 'https://api.ebay.com';
+
+export async function createEbayDraft(product: Product) {
+  const token = process.env.EBAY_ACCESS_TOKEN;
+  if (!token) {
+    throw new Error('Missing EBAY_ACCESS_TOKEN environment variable');
+  }
+
+  const body = {
+    title: product.name,
+    description: product.description,
+    availability: {
+      shipToLocationAvailability: {
+        quantity: product.quantity,
+      },
+    },
+    price: {
+      value: product.price,
+      currency: 'EUR',
+    },
+    categoryId: product.ebayCategoryId,
+    sku: product.code,
+    condition: product.listingStatus,
+  };
+
+  const res = await fetch(`${EBAY_API_BASE}/sell/listing/v1/item_draft`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`eBay API error: ${res.status} ${text}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- integrate eBay Sell API to create listing drafts
- expose `/api/ebay/drafts` endpoint
- allow products table to send items to eBay drafts

## Testing
- `npm run lint` *(fails: prompting for ESLint config)*
- `npm run typecheck` *(fails: Cannot find module '@genkit-ai/next/cors')*


------
https://chatgpt.com/codex/tasks/task_e_68958861460c8323b21f3ba8e94713b5