### PR TITLE
feat: add auth middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('__session')?.value || request.headers.get('Authorization');
+
+  if (!token) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!login|api).*)'],
+};


### PR DESCRIPTION
## Summary
- add middleware to check auth token and redirect to login when missing

## Testing
- `npm run lint` (interactive prompt prevents completion)
- `npm run typecheck` (fails: Type '{ technicalSpecs: Record<string, string> | undefined; code: string; name: string; listingStatus: "draft" | ... }' is not assignable to type 'Product')
- `curl -I http://localhost:3000/settings`


------
https://chatgpt.com/codex/tasks/task_e_68986f042cd08323bc324584738bce19