### PR TITLE
chore: configure build and env for apphosting

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,7 +1,20 @@
 # Settings to manage and configure a Firebase App Hosting backend.
 # https://firebase.google.com/docs/app-hosting/configure
 
+build:
+  command: npm run build
+  dir: .
+
 runConfig:
   # Increase this value if you'd like to automatically spin up
   # more instances in response to increased traffic.
   maxInstances: 1
+  env:
+    NEXT_PUBLIC_FIREBASE_API_KEY: "<api-key>"
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "<auth-domain>"
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID: "<project-id>"
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "<bucket>"
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "<sender-id>"
+    NEXT_PUBLIC_FIREBASE_APP_ID: "<app-id>"
+    NEXT_PUBLIC_MICROSOFT_TENANT_ID: "<tenant-id>"
+    FIREBASE_SERVICE_ACCOUNT: "<json-service-account>"


### PR DESCRIPTION
## Summary
- add build command for Firebase App Hosting
- define runtime env vars for Firebase and Microsoft auth

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(aborted: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Type '{ technicalSpecs: Record<string, string> | undefined; code: string; name: string; listingStatus: "draft" | "listed" | "error" | "new" | "used" | "refurbished"; price: number; ... 12 more ...; keywords: string[]; } | { ...; }' is not assignable to type 'Product'.)*
- `firebase deploy` *(fails: Not in a Firebase app directory (could not locate firebase.json))*

------
https://chatgpt.com/codex/tasks/task_e_68986efabbd88323be9d058967992d49