### PR TITLE
route: expose AI flows via API

### DIFF
--- a/src/app/api/ai/find-ean/route.ts
+++ b/src/app/api/ai/find-ean/route.ts
@@ -1,0 +1,7 @@
+import { findEan } from '@/ai/flows/find-ean';
+
+export async function POST(req: Request) {
+  const input = await req.json();
+  const result = await findEan(input);
+  return Response.json(result);
+}

--- a/src/app/api/ai/find-ebay-category-id/route.ts
+++ b/src/app/api/ai/find-ebay-category-id/route.ts
@@ -1,0 +1,7 @@
+import { findEbayCategoryId } from '@/ai/flows/find-ebay-category-id';
+
+export async function POST(req: Request) {
+  const input = await req.json();
+  const result = await findEbayCategoryId(input);
+  return Response.json(result);
+}


### PR DESCRIPTION
## Summary
- add API routes for `findEbayCategoryId` and `findEan` flows
- call new AI endpoints from product form instead of importing server-only modules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689902d96d2c8323b9a0deb665a7a2ce