### PR TITLE
Validate Microsoft tenant ID before login

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -11,6 +11,7 @@ import {
 import { auth } from '@/lib/firebase/client';
 import { usePathname, useRouter } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
 
 type AuthContextType = {
   user: User | null;
@@ -26,6 +27,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = React.useState(true);
   const router = useRouter();
   const pathname = usePathname();
+  const { toast } = useToast();
 
   React.useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => {
@@ -51,9 +53,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const loginWithMicrosoft = async () => {
-    const tenantId = process.env.NEXT_PUBLIC_MICROSOFT_TENANT_ID;
+    const tenantId = process.env.NEXT_PUBLIC_MICROSOFT_TENANT_ID?.trim();
     if (!tenantId) {
-        throw new Error('Microsoft Tenant ID is not configured. Please set NEXT_PUBLIC_MICROSOFT_TENANT_ID in your environment variables.');
+      toast({
+        variant: 'destructive',
+        title: 'Configuration Error',
+        description: 'Microsoft Tenant ID is not configured.',
+      });
+      throw new Error(
+        'Microsoft Tenant ID is not configured. Please set NEXT_PUBLIC_MICROSOFT_TENANT_ID in your environment variables.'
+      );
     }
     const provider = new OAuthProvider('microsoft.com');
     provider.setCustomParameters({


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_MICROSOFT_TENANT_ID` once and validate
- prevent login when tenant ID is missing by throwing error and showing a toast

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689902f0cddc8323a6cc9b3ad4b24056