### PR TITLE
fix: stabilize search param dependency in auth redirect

### DIFF
--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -31,6 +31,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const search = searchParams.toString();
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, current => {
@@ -46,14 +47,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const isAuthPage = pathname === '/login';
 
     if (!user && !isAuthPage) {
-      const nextPath = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : '');
+      const nextPath = pathname + (search ? `?${search}` : '');
       const url = nextPath ? `/login?next=${encodeURIComponent(nextPath)}` : '/login';
       router.replace(url);
     } else if (user && isAuthPage) {
-      const next = searchParams.get('next') || '/';
+      const next = new URLSearchParams(search).get('next') || '/';
       router.replace(next);
     }
-  }, [user, loading, pathname, searchParams, router]);
+  }, [user, loading, pathname, search, router]);
 
   const loginWithMicrosoft = useCallback(async () => {
     await setPersistence(auth, browserLocalPersistence);


### PR DESCRIPTION
## Summary
- derive a `search` string from `useSearchParams` for redirect logic
- depend on the `search` string instead of the `searchParams` object to avoid redirect loops

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68992e8fb6b0832391c5072fa0388577