### PR TITLE
chore: add dotenv config and use NEXT_PUBLIC_ERPNEXT_URL for ERPNext

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_ERPNEXT_URL=https://your-erp.example.com
+ERPNEXT_API_KEY=your_api_key
+ERPNEXT_API_SECRET=your_api_secret

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ npm install
 
 	3.	Configure environment variables in .env
 
-ERP_API_URL=https://erp.example.com
-ERP_API_KEY=xxxxx
-ERP_API_SECRET=xxxxx
+NEXT_PUBLIC_ERPNEXT_URL=https://erp.example.com
+ERPNEXT_API_KEY=xxxxx
+ERPNEXT_API_SECRET=xxxxx
 GENKIT_API_KEY=xxxxx
 
 	4.	Start the development server

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,8 @@
-import type {NextConfig} from 'next';
+import type { NextConfig } from 'next';
+import { config as loadEnv } from 'dotenv';
+
+// Load environment variables from .env files
+loadEnv();
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/src/app/api/proxy-erpnext/route.ts
+++ b/src/app/api/proxy-erpnext/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: Request) {
   try {
     const { endpoint, method = 'GET', body } = await req.json();
 
-    const url = process.env.ERPNEXT_URL;
+    const url = process.env.NEXT_PUBLIC_ERPNEXT_URL;
     const apiKey = process.env.ERPNEXT_API_KEY;
     const apiSecret = process.env.ERPNEXT_API_SECRET;
     
@@ -72,7 +72,7 @@ export async function POST(req: Request) {
     console.error("API Proxy Error:", err);
     // Provide a more specific error message for network/fetch failures
     const errorMessage = err.cause?.code === 'ENOTFOUND'
-      ? `Could not connect to ERPNext server at ${process.env.ERPNEXT_URL}. Please check the URL and network connection.`
+      ? `Could not connect to ERPNext server at ${process.env.NEXT_PUBLIC_ERPNEXT_URL}. Please check the URL and network connection.`
       : err.message || 'An unexpected error occurred in the API proxy.';
       
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- load env vars via `dotenv` in Next.js config
- document environment variables and ship example `.env`
- proxy ERPNext requests using `NEXT_PUBLIC_ERPNEXT_URL`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6899438ad2ec8323bf59c80cdc072aca